### PR TITLE
feat(detail): show similar matches, not just exact matches in other thumbnails

### DIFF
--- a/blocks/asset-results/asset-results.css
+++ b/blocks/asset-results/asset-results.css
@@ -325,7 +325,7 @@ main .asset-results-dimensions::before {
     main .asset-results-oneup > div {
       display: grid;
       grid-template-columns: auto 320px;
-      grid-template-rows: calc(100vh - 190px) 220px auto;
+      grid-template-rows: calc(100vh - 250px) 220px;
     }
     
     main .asset-results-oneup > div > .asset-results-oneup-picture {

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -266,7 +266,7 @@ export default function decorate(block) {
       });
     });
     
-    const similarserviceurl = new URL('https://helix-pages.anywhere.run/helix-services/asset-ingestor@ci315');
+    const similarserviceurl = new URL('https://helix-pages.anywhere.run/helix-services/asset-ingestor@v1');
     similarserviceurl.searchParams.set('url', asset.image);
     const similarassets = fetch(similarserviceurl.href).then(async res => {
       const { hits } = await res.json();

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -221,9 +221,9 @@ export default function decorate(block) {
     const infoConfig = [{
       title: 'Information',
       infos: [
-        { title: 'File', value: asset.type.toUpperCase(), alts: otherassets.map(o => o.type.toUpperCase()) },
-        { title: 'Created', value: asset.created && new Date(asset.created).toLocaleDateString() },
-        { title: 'Modified', value: asset.modified && new Date(asset.modified).toLocaleDateString() },
+        { title: 'File', value: asset?.type.toUpperCase(), alts: otherassets.map(o => o.type?.toUpperCase()) },
+        { title: 'Created', value: asset?.created && new Date(asset.created).toLocaleDateString() },
+        { title: 'Modified', value: asset?.modified && new Date(asset.modified).toLocaleDateString() },
         { title: 'Size', value: '193MB' },
         { title: 'Width', value: `${asset.width}px`, alts: otherassets.map(o => `${o.width}px`) },
         { title: 'Height', value: `${asset.height}px`, alts: otherassets.map(o => `${o.height}px`) },
@@ -263,6 +263,20 @@ export default function decorate(block) {
         const allotherassets = [asset, ...otherassets].filter(a => a !== myasset);
         modal.remove();
         showOneUp(myasset, allotherassets);
+      });
+    });
+    
+    const similarserviceurl = new URL('https://helix-pages.anywhere.run/helix-services/asset-ingestor@ci315');
+    similarserviceurl.searchParams.set('url', asset.image);
+    const similarassets = fetch(similarserviceurl.href).then(async res => {
+      const { hits } = await res.json();
+      hits.forEach(otherasset => {
+        const a = document.createElement('a');
+        const detailurl = new URL(window.location.href);
+        detailurl.searchParams.set('q', `assetID:${otherasset.assetID}`);
+        a.href = detailurl.href;
+        a.appendChild(createOptimizedPicture(otherasset.image));
+        moreDiv.appendChild(a);
       });
     });
 


### PR DESCRIPTION
 the initial list of similar assets comes straight from the index, but will visually be verrrry similar. In addition, we query the asset ingestion service (which will query CAI) for a looser list of visually similar assets. At the moment, this depends on adobe/helix-asset-ingestor#26 and will return a list of assets that are not very similar. We haven't re-indexed with the new service, so the list of similar images contains the entire test data set, which is very small.

https://similar-instead-of-exact--helix-assets-ui--adobe.hlx.page/?q=assetID%3A178b1fc8d50ec96c5d7d4cd918f5e0264b3dc2b83#sidebar