### PR TITLE
limit amount of tags shown in masonry, if longer use embedded scrolling

### DIFF
--- a/blocks/asset-results/asset-results.css
+++ b/blocks/asset-results/asset-results.css
@@ -207,6 +207,8 @@ main p.asset-results-tags {
   margin: 0.6em 0;
   display: flex;
   flex-wrap: wrap;
+  max-height: 55px;
+  overflow: scroll;
 }
 
 main .asset-results-views::before, main .asset-results-dimensions::before {


### PR DESCRIPTION
In masonry view, if there are many tags, they just increase the size of the entire hover detail view, at some point making it impossible to click the link to the detail view.

This PR limits the size to allow for 2 rows of tags, and if there are more you can scroll inside the tags "box" (or see the full list in the detail view).

## Before
<img width="505" alt="before" src="https://user-images.githubusercontent.com/229022/170602767-b257475d-81e1-4a65-a212-61cce162166b.png">

## After
<img width="460" alt="after" src="https://user-images.githubusercontent.com/229022/170602795-bd4b21c1-5882-4013-ba01-e2b802fa91f1.png">

URLs for testing:
* https://limit-tags--helix-assets-ui--adobe.hlx3.page/
* https://limit-tags--helix-assets-ui--adobe.hlx3.page/?q=adobe+logo
