### PR TITLE
UI improvements

### DIFF
--- a/blocks/asset-results/asset-results.css
+++ b/blocks/asset-results/asset-results.css
@@ -11,44 +11,27 @@ main .asset-results {
 }
 
 main .asset-results-view-switcher {
-  width: 16px;
+  display: block;
+  float: right;
+  width: 100px;
   height: 32px;
-  background-position: center left;
-  background-size: contain;
+  padding-right: 32px;
+  text-align: right;
+  color: #888;
+  font-weight: 600;
+  font-size: 13px;
   background-repeat: no-repeat;
-  background-image: url('grid.svg');
-  display: inline-block;
+  background-position: 110px 2px;
+  background-size: 16px;
+  cursor: pointer;
 }
 
 main .asset-results-view-switcher.assets-results-view-grid {
   background-image: url('grid.svg');
 }
 
-main .asset-results-view-switcher.assets-results-view-grid::after {
-  content: 'Grid View';
-  padding-left: 5px;
-}
-
 main .asset-results-view-switcher.assets-results-view-masonry {
   background-image: url('masonry.svg');
-}
-
-main .asset-results-view-switcher.assets-results-view-masonry::after {
-  content: 'Masonry View';
-  padding-left: 5px;
-}
-
-main .asset-results-view-switcher::after {
-  display: inline-block;
-  width: 200px;
-  padding: 0;
-  margin: 0;
-  line-height: 0;
-  margin-left: 20px;
-  color: #888;
-  font-weight: 600;
-  font-size: 13px;
-  margin-top: 1.25em;
 }
 
 main .asset-results ol {
@@ -134,9 +117,10 @@ main .asset-results-masonry-item img {
 }
 
 main .asset-results-controls .asset-results-heading img {
-  padding: 2px 10px 5px 0;
+  padding: 5px 10px 5px 0;
   margin-right: 10px;
   border-right: 1px solid #ccc;
+  cursor: pointer;
 }
 
 main .asset-results-oneup .asset-results-oneup-more img {
@@ -166,7 +150,14 @@ main .asset-results-controls {
 }
 
 main .asset-results-controls .asset-results-heading {
-  display: flex;
+  display: block;
+  float: left;
+  width: 300px;
+}
+
+main .asset-results-controls .asset-results-heading-text {
+  vertical-align: top;
+  line-height: 30px;
 }
 
 main .asset-results-masonry {

--- a/blocks/asset-results/asset-results.css
+++ b/blocks/asset-results/asset-results.css
@@ -236,6 +236,7 @@ main .asset-results-oneup header > div {
   position: fixed;
   left: 0;
   right: 0;
+  height: 30px;
 }
 
 main .asset-results-oneup .asset-results-oneup-more {

--- a/blocks/asset-results/asset-results.css
+++ b/blocks/asset-results/asset-results.css
@@ -26,6 +26,7 @@ main .asset-results-view-switcher.assets-results-view-grid {
 
 main .asset-results-view-switcher.assets-results-view-grid::after {
   content: 'Grid View';
+  padding-left: 5px;
 }
 
 main .asset-results-view-switcher.assets-results-view-masonry {
@@ -34,6 +35,7 @@ main .asset-results-view-switcher.assets-results-view-masonry {
 
 main .asset-results-view-switcher.assets-results-view-masonry::after {
   content: 'Masonry View';
+  padding-left: 5px;
 }
 
 main .asset-results-view-switcher::after {
@@ -46,6 +48,7 @@ main .asset-results-view-switcher::after {
   color: #888;
   font-weight: 600;
   font-size: 13px;
+  margin-top: 1.25em;
 }
 
 main .asset-results ol {
@@ -131,7 +134,7 @@ main .asset-results-masonry-item img {
 }
 
 main .asset-results-controls .asset-results-heading img {
-  padding: 5px 10px 5px 0;
+  padding: 2px 10px 5px 0;
   margin-right: 10px;
   border-right: 1px solid #ccc;
 }

--- a/blocks/asset-results/asset-results.css
+++ b/blocks/asset-results/asset-results.css
@@ -162,13 +162,20 @@ main .asset-results-masonry-item {
   position: relative;
 }
 
-main .asset-results-caption {
+main p.asset-results-caption {
   font-weight: bold;
   grid-area: caption;
+  margin-bottom: 10px;
+}
+
+main .asset-results-caption a {
+  color: white;
 }
 
 main .asset-results-source {
   grid-area: source;
+  overflow: hidden;
+  max-height: 1.5em;
 }
 
 main .asset-results-tags span {
@@ -190,7 +197,7 @@ main p.asset-results-tags {
   margin: 0.6em 0;
   display: flex;
   flex-wrap: wrap;
-  max-height: 55px;
+  max-height: 27px;
   overflow: scroll;
 }
 

--- a/blocks/asset-results/asset-results.css
+++ b/blocks/asset-results/asset-results.css
@@ -129,19 +129,6 @@ main .asset-results-oneup .asset-results-oneup-more img {
   margin: 5px
 }
 
-main .asset-results-oneup .asset-results-oneup-picture img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-main .asset-results .asset-results-grid ol li img {
-  background-color: #00000020;
-  height: 154px;
-  width: 154px;
-  object-fit: contain;
-}
-
 main .asset-results-controls {
   padding: 8px 19px;
   font-size: 1rem;
@@ -262,7 +249,22 @@ main .asset-results-oneup .asset-results-oneup-picture {
   background-color: #ddd;
   padding: 16px;
   box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
+
+main .asset-results-oneup .asset-results-oneup-picture img {
+  max-width: 100%;
+}
+
+main .asset-results .asset-results-grid ol li img {
+  background-color: #00000020;
+  height: 154px;
+  width: 154px;
+  object-fit: contain;
+}
+
 
 main .asset-results-oneup .asset-results-oneup-section {
   padding: 16px;

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -146,7 +146,8 @@ export default function decorate(block) {
   }
 
   function getDownloadURL(asset) {
-    return asset.image;
+    // use current origin to make downloads work well in browsers
+    return `${window.location.origin}${new URL(asset.image).pathname}`;
   }
 
   const showResults = (results) => {

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -11,11 +11,18 @@ export default function decorate(block) {
   block.appendChild(list);
 
   const masonry = document.createElement('div');
-  masonry.className = 'asset-results-masonry hidden';
-  block.appendChild(masonry);
-
   const grid = document.createElement('div');
-  grid.className = 'asset-results-grid';
+
+  const resultsView = window.localStorage.getItem('resultsView');
+  if (resultsView === 'masonry') {
+    masonry.className = 'asset-results-masonry';
+    grid.className = 'asset-results-grid hidden';
+  } else {
+    masonry.className = 'asset-results-masonry hidden';
+    grid.className = 'asset-results-grid';
+  }
+
+  block.appendChild(masonry);
   block.append(grid);
 
   class Masonry {
@@ -131,7 +138,7 @@ export default function decorate(block) {
         });
     }
     counter.innerHTML = `<div class="asset-results-heading"><img src="/blocks/asset-results/filter.svg">Assets & files (${results.nbHits})</div>
-  <div class="asset-results-view-switcher assets-results-view-masonry"></div>`;
+  <div class="asset-results-view-switcher ${resultsView === 'masonry' ? 'assets-results-view-grid' : 'assets-results-view-masonry'}"></div>`;
 
     const filterbutton = counter.firstElementChild;
     filterbutton.addEventListener('click', () => {
@@ -147,9 +154,11 @@ export default function decorate(block) {
       if (switcher.classList.contains('assets-results-view-grid')) {
         switcher.classList.remove('assets-results-view-grid');
         switcher.classList.add('assets-results-view-masonry');
+        window.localStorage.setItem('resultsView', 'grid');
       } else {
         switcher.classList.add('assets-results-view-grid');
         switcher.classList.remove('assets-results-view-masonry');
+        window.localStorage.setItem('resultsView', 'masonry');
       }
       grid.classList.toggle('hidden');
       masonry.classList.toggle('hidden');
@@ -226,9 +235,7 @@ export default function decorate(block) {
       </div>
       <div class="header-filename"></div>
       <div class="header-button">
-        <a download="${getDownloadFilename(asset)}" href="${asset.image}" title="${asset.caption}">
-          <button class="primary">Download</button>
-        </a>
+        <a download="${getDownloadFilename(asset)}" href="${asset.image}" title="${asset.caption}"><button class="primary">Download</button></a>
         <button name='close' class="secondary">Done</button>
       </div>
     </div>

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -137,10 +137,10 @@ export default function decorate(block) {
           });
         });
     }
-    counter.innerHTML = `<div class="asset-results-heading"><img src="/blocks/asset-results/filter.svg">Assets & files (${results.nbHits})</div>
-  <div class="asset-results-view-switcher ${resultsView === 'masonry' ? 'assets-results-view-grid' : 'assets-results-view-masonry'}"></div>`;
+    counter.innerHTML = `<div class="asset-results-heading"><img src="/blocks/asset-results/filter.svg"><span class="asset-results-heading-text">Assets & Files (${results.nbHits})</span></div>
+  <div class="asset-results-view-switcher ${resultsView === 'masonry' ? 'assets-results-view-grid' : 'assets-results-view-masonry'}">${resultsView === 'masonry' ? 'Grid View' : 'Masonry View'}</div>`;
 
-    const filterbutton = counter.firstElementChild;
+    const filterbutton = counter.querySelector('.asset-results-heading>img');
     filterbutton.addEventListener('click', () => {
       block.parentElement.parentElement.classList.toggle('show-sidebar');
       const url = new URL(window.location.href);
@@ -155,10 +155,12 @@ export default function decorate(block) {
         switcher.classList.remove('assets-results-view-grid');
         switcher.classList.add('assets-results-view-masonry');
         window.localStorage.setItem('resultsView', 'grid');
+        switcher.innerHTML = 'Masonry View';
       } else {
         switcher.classList.add('assets-results-view-grid');
         switcher.classList.remove('assets-results-view-masonry');
         window.localStorage.setItem('resultsView', 'masonry');
+        switcher.innerHTML = 'Grid View';
       }
       grid.classList.toggle('hidden');
       masonry.classList.toggle('hidden');

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -267,7 +267,7 @@ export default function decorate(block) {
       <div class="header block" data-block-name="header" data-block-status="loaded">
       <div class="header-brand">
         <a href="http://localhost:3000/?q=assetID%3A12e16e067b6259f02449f35a35c5b2f7505550167&amp;index=assets"><img src="/styles/adobe.svg"></a>
-        Helix Assets
+        Assets Across Adobe
       </div>
       <div class="header-filename"></div>
       <div class="header-button">

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -35,7 +35,7 @@ export default function decorate(block) {
     const detailURL = new URL(window.location.href);
     detailURL.search = '';
     detailURL.searchParams.set('assetId', assetID);
-    window.history.pushState(null, null, detailURL.href);
+    window.history.pushState({ inApp: true }, null, detailURL.href);
 
     showOneUp(searchResults[assetID], []);
   }
@@ -286,14 +286,16 @@ export default function decorate(block) {
     </div>`;
     const closeButton = modal.querySelector('.header-button button[name=close]');
     function closeOneup() {
-      modal.remove();
-      block.style.display = 'block';
-      if (window.history.length <= 1) {
+      if (window.history.state && window.history.state.inApp) {
+        // if we opened within the app, just close modal
+        modal.remove();
+        block.style.display = 'block';
+        window.history.back();
+      } else {
+        // if the detail url was opened directly, we have to reload the page for the search view
         const baseURL = new URL(window.location.href);
         baseURL.search = '';
         window.location.href = baseURL.href;
-      } else {
-        window.history.back();
       }
     }
     closeButton.addEventListener('click', () => {

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -25,6 +25,21 @@ export default function decorate(block) {
   block.appendChild(masonry);
   block.append(grid);
 
+  let searchResults = {};
+  let showOneUp;
+
+  function handleOneupClick(e, element) {
+    e.preventDefault();
+
+    const assetID = element.dataset.assetid;
+    const detailURL = new URL(window.location.href);
+    detailURL.search = '';
+    detailURL.searchParams.set('assetId', assetID);
+    window.history.pushState(null, null, detailURL.href);
+
+    showOneUp(searchResults[assetID], []);
+  }
+
   class Masonry {
     constructor(listEl, masonryEl) {
       this.list = listEl;
@@ -63,9 +78,15 @@ export default function decorate(block) {
       items.forEach((result) => {
         const img = result.querySelector('img');
         if (img.complete && add) {
+          // const item = result.cloneNode(true);
           const item = document.createElement('div');
           item.className = 'asset-results-masonry-item';
           item.innerHTML = result.innerHTML;
+
+          item.querySelectorAll('a:first-child, .asset-results-caption a').forEach((el) => {
+            el.addEventListener('click', (e) => handleOneupClick(e, el));
+          });
+
           const col = findBestCol();
           col.dataset.height = +col.dataset.height + (img.height / img.width);
           col.append(item);
@@ -124,7 +145,12 @@ export default function decorate(block) {
     return `${file}.${ext}`;
   }
 
+  function getDownloadURL(asset) {
+    return asset.image;
+  }
+
   const showResults = (results) => {
+    searchResults = {};
     const datalist = document.getElementById('query-suggestions');
     if (results.facets && datalist) {
       Object.entries(results.facets)
@@ -167,20 +193,24 @@ export default function decorate(block) {
     });
 
     results.hits.forEach((hit) => {
+      searchResults[hit.assetID] = hit;
+
       const item = document.createElement('li');
       const topurl = new URL(hit.topurl || hit.sourceURL || hit.image);
       const imageURL = new URL(hit.image);
       const detailURL = new URL(window.location.href);
-      detailURL.searchParams.set('q', `assetID:${hit.assetID}`);
+      detailURL.search = '';
+      detailURL.searchParams.set('assetId', hit.assetID);
+
       imageURL.searchParams.set('width', 750);
       const description = hit.alt || hit.caption;
       const picture = createOptimizedPicture(imageURL.href, description, false, [{ width: '750' }]);
       const path = getDisplayPath(topurl.href, hit.sourceType);
 
       item.innerHTML = `
-        <a href="${detailURL.href}">${picture.outerHTML}</a>
+        <a href="${detailURL.href}" data-assetid="${hit.assetID}">${picture.outerHTML}</a>
         <div class="asset-results-details source-${hit.sourceType}">
-          <p class="asset-results-caption"><a href="${detailURL.href}">${description}</a></p>
+          <p class="asset-results-caption"><a href="${detailURL.href}" data-assetid="${hit.assetID}">${description}</a></p>
           <p class="asset-results-source"><a href="${topurl.href}">${path}</a></p>
           <p class="asset-results-views">${humanSize(hit.views)}</p>
           <p class="asset-results-dimensions">${hit.height} x ${hit.width}</p>
@@ -188,6 +218,9 @@ export default function decorate(block) {
         </div>
       `;
       list.appendChild(item);
+    });
+    list.querySelectorAll('li > a, .asset-results-caption a').forEach((el) => {
+      el.addEventListener('click', (e) => handleOneupClick(e, el));
     });
 
     masonry.textContent = '';
@@ -197,7 +230,7 @@ export default function decorate(block) {
     grid.append(list);
   };
 
-  const showOneUp = async (asset, otherassets) => {
+  showOneUp = async (asset, otherassets) => {
     const createInfo = (panelConfig) => {
       const panel = document.createElement('div');
       panelConfig.forEach((sectionConfig) => {
@@ -237,7 +270,7 @@ export default function decorate(block) {
       </div>
       <div class="header-filename"></div>
       <div class="header-button">
-        <a download="${getDownloadFilename(asset)}" href="${asset.image}" title="${asset.caption}"><button class="primary">Download</button></a>
+        <a download="${getDownloadFilename(asset)}" href="${getDownloadURL(asset)}" title="${asset.caption}"><button class="primary">Download</button></a>
         <button name='close' class="secondary">Done</button>
       </div>
     </div>
@@ -251,10 +284,28 @@ export default function decorate(block) {
       </div>
     </div>`;
     const closeButton = modal.querySelector('.header-button button[name=close]');
-    closeButton.addEventListener('click', () => {
+    function closeOneup() {
       modal.remove();
-      window.history.back();
+      block.style.display = 'block';
+      if (window.history.length <= 1) {
+        const baseURL = new URL(window.location.href);
+        baseURL.search = '';
+        window.location.href = baseURL.href;
+      } else {
+        window.history.back();
+      }
+    }
+    closeButton.addEventListener('click', () => {
+      closeOneup();
     });
+
+    // this needs a bit more refinement
+    // document.body.addEventListener('keypress', (e) => {
+    //   if (e.key === 'Escape') {
+    //     closeOneup();
+    //   }
+    // });
+
     const pictureDiv = modal.querySelector('.asset-results-oneup-picture');
     const moreDiv = modal.querySelector('.asset-results-oneup-more');
 
@@ -305,6 +356,10 @@ export default function decorate(block) {
       });
     });
 
+    pictureDiv.appendChild(createOptimizedPicture(asset.image));
+    block.parentElement.append(modal);
+    block.style.display = 'none';
+
     const similarserviceurl = new URL('https://helix-pages.anywhere.run/helix-services/asset-ingestor@v1');
     similarserviceurl.searchParams.set('url', asset.image);
 
@@ -314,7 +369,8 @@ export default function decorate(block) {
       hits.forEach((otherasset) => {
         const a = document.createElement('a');
         const detailurl = new URL(window.location.href);
-        detailurl.searchParams.set('q', `assetID:${otherasset.assetID}`);
+        detailurl.search = '';
+        detailurl.searchParams.set('assetId', otherasset.assetID);
         a.href = detailurl.href;
         a.appendChild(createOptimizedPicture(otherasset.image));
         moreDiv.appendChild(a);
@@ -323,31 +379,36 @@ export default function decorate(block) {
       // eslint-disable-next-line no-console
       console.log('Could not load similar images:', e);
     }
-
-    pictureDiv.appendChild(createOptimizedPicture(asset.image));
-    block.append(modal);
   };
 
+  // this is an URL state change listener
   const search = () => {
     const myurl = new URL(window.location.href);
-    const query = myurl.searchParams.get('q') || '';
+
     const index = myurl.searchParams.get('index') || 'assets';
-
+    const query = myurl.searchParams.get('q') || '';
     const terms = query.split(' ');
-
-    const filters = [
-      ...(Array.from(myurl.searchParams.entries())
-        .filter(([param]) => param.match(/f:(.*)-minimum/))
-        .map(([param, value]) => `${param.replace(/f:(.*)-minimum/, '$1')}>${value}`)),
-      ...(Array.from(myurl.searchParams.entries())
-        .filter(([param]) => param.match(/f:(.*)-maximum/))
-        .map(([param, value]) => `${param.replace(/f:(.*)-maximum/, '$1')}<${value}`)),
-      ...(terms.filter((term) => term.match(':'))),
-      ...myurl.searchParams.getAll('ff'),
-    ]
-      .map((t) => t.split(':').map((s) => (s.match(/ /) ? `"${s}"` : s)).join(':'))
-      .join(' AND ');
     const words = terms.filter((term) => !term.match(':')).join(' ');
+
+    let filters;
+
+    const assetId = myurl.searchParams.get('assetId');
+    if (assetId) {
+      filters = `assetID:${assetId}`;
+    } else {
+      filters = [
+        ...(Array.from(myurl.searchParams.entries())
+          .filter(([param]) => param.match(/f:(.*)-minimum/))
+          .map(([param, value]) => `${param.replace(/f:(.*)-minimum/, '$1')}>${value}`)),
+        ...(Array.from(myurl.searchParams.entries())
+          .filter(([param]) => param.match(/f:(.*)-maximum/))
+          .map(([param, value]) => `${param.replace(/f:(.*)-maximum/, '$1')}<${value}`)),
+        ...(terms.filter((term) => term.match(':'))),
+        ...myurl.searchParams.getAll('ff'),
+      ]
+        .map((t) => t.split(':').map((s) => (s.match(/ /) ? `"${s}"` : s)).join(':'))
+        .join(' AND ');
+    }
 
     const url = new URL(`https://SWFXY1CU7X-dsn.algolia.net/1/indexes/${index}`);
     url.searchParams.set('query', words);

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -212,8 +212,8 @@ export default function decorate(block) {
         <a href="${detailURL.href}" data-assetid="${hit.assetID}">${picture.outerHTML}</a>
         <div class="asset-results-details source-${hit.sourceType}">
           <p class="asset-results-caption"><a href="${detailURL.href}" data-assetid="${hit.assetID}">${description}</a></p>
-          <p class="asset-results-source"><a href="${topurl.href}">${path}</a></p>
-          <p class="asset-results-views">${humanSize(hit.views)}</p>
+          <!-- <p class="asset-results-source"><a href="${topurl.href}">${path}</a></p> -->
+          <!-- <p class="asset-results-views">${humanSize(hit.views)}</p> -->
           <p class="asset-results-dimensions">${hit.height} x ${hit.width}</p>
           <p class="asset-results-tags"><span>${(hit.tags || []).join('</span> <span>')}</span></p>
         </div>

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -51,30 +51,36 @@ export default async function decorate(block) {
     }
   });
 
+  let delayTimer;
   // update the URL when the input changes
   textfield.addEventListener('input', () => {
-    const myurl = new URL(window.location.href);
-    myurl.searchParams.set('q', textfield.value);
-    window.changeURLState({ query: textfield.value }, myurl.href);
+    clearTimeout(delayTimer);
+    delayTimer = setTimeout(() => {
+      // /////////////////////////////////////////////////////////////
+      const myurl = new URL(window.location.href);
+      myurl.searchParams.set('q', textfield.value);
+      window.changeURLState({ query: textfield.value }, myurl.href);
 
-    const query = myurl.searchParams.get('q');
+      const query = myurl.searchParams.get('q');
 
-    const url = new URL('https://SWFXY1CU7X-dsn.algolia.net/1/indexes/assets_query_suggestions');
-    url.searchParams.set('query', query);
-    url.searchParams.set('x-algolia-api-key', 'bd35440a1d9feb709a052226f1aa70d8');
-    url.searchParams.set('x-algolia-application-id', 'SWFXY1CU7X');
+      const url = new URL('https://SWFXY1CU7X-dsn.algolia.net/1/indexes/assets_query_suggestions');
+      url.searchParams.set('query', query);
+      url.searchParams.set('x-algolia-api-key', 'bd35440a1d9feb709a052226f1aa70d8');
+      url.searchParams.set('x-algolia-application-id', 'SWFXY1CU7X');
 
-    fetch(url.href).then(async (res) => {
-      const { hits } = await res.json();
-      if (hits.length) {
-        datalist.innerHTML = '';
-      }
-      hits.forEach((hit) => {
-        const option = document.createElement('option');
-        option.innerHTML = hit.query;
-        datalist.append(option);
+      fetch(url.href).then(async (res) => {
+        const { hits } = await res.json();
+        if (hits.length) {
+          datalist.innerHTML = '';
+        }
+        hits.forEach((hit) => {
+          const option = document.createElement('option');
+          option.innerHTML = hit.query;
+          datalist.append(option);
+        });
       });
-    });
+      // /////////////////////////////////////////////////////////////
+    }, 500);
   });
   textfield.after(datalist);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -131,6 +131,10 @@ button {
   padding: 6px 18px;
 }
 
+button.primary {
+  border: 2px solid var(--link-color);
+}
+
 button.secondary {
   color: var(--text-color);
   border: 2px solid currentColor;
@@ -140,6 +144,10 @@ button.secondary {
 button:hover {
   background-color: var(--link-hover-color);
   cursor: pointer;
+}
+
+button.primary:hover {
+  border: 2px solid var(--link-hover-color);
 }
 
 button.secondary:hover {


### PR DESCRIPTION
* UI: make oneup display much faster by skipping the network requests
* UI: 500ms delay on typing before search is triggered
* UI: fix download links to ensure same origin
* UI: do not upscale images in oneup view
* UI: Assets Across Adobe instead of Helix Assets in oneup header
* UI: improve results view heading controls
  - move switcher to top right
  - use pointer cursors for clickable elements
  - better align the filter icon vs. "Asset & Files"
  - capitalize "Files"
* feat: improve UI for result view switcher and download button
* UI: Assets Across Adobe instead of Helix Assets in oneup header
* UI: improve hover details on masonry view
  - make it smaller
  - use white for link
  - remove source link (still visible in oneup)
  - drop the usually empty view count
* fix: hide filters sidebar properly

Test URLs:

* https://ui-improvements--helix-assets-ui--adobe.hlx3.page
* https://ui-improvements--helix-assets-ui--adobe.hlx3.page/?q=#sidebar
* https://ui-improvements--helix-assets-ui--adobe.hlx3.page/?assetId=1e4df33b1cb33045d3ebb32c7d848e037c055f6f6