### PR TITLE
Implement tenant authentication

### DIFF
--- a/blocks/asset-results/asset-results.css
+++ b/blocks/asset-results/asset-results.css
@@ -94,6 +94,10 @@ main .asset-results-grid .asset-results-views, main .asset-results-grid .asset-r
   display: none;
 }
 
+main .asset-results-masonry .asset-results-source, main .asset-results-masonry .asset-results-views {
+  display: none;
+}
+
 main .asset-results-masonry-item p {
   word-break: break-all;
   font-size: 0.8rem;
@@ -165,15 +169,21 @@ main .asset-results-masonry-item {
 main p.asset-results-caption {
   font-weight: bold;
   grid-area: caption;
-  margin-bottom: 10px;
-}
-
-main .asset-results-caption a {
-  color: white;
 }
 
 main .asset-results-source {
   grid-area: source;
+}
+
+main .asset-results-masonry-item p.asset-results-caption {
+  margin-bottom: 10px;
+}
+
+main .asset-results-masonry-item .asset-results-caption a {
+  color: white;
+}
+
+main .asset-results-masonry-item .asset-results-source {
   overflow: hidden;
   max-height: 1.5em;
 }

--- a/blocks/asset-results/asset-results.css
+++ b/blocks/asset-results/asset-results.css
@@ -90,6 +90,10 @@ main .asset-results .asset-results-grid .asset-results-details::after {
   background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" height="20" width="20"><circle cx="5" cy="10" r="4" fill="%23519B7B"/></svg>') left center no-repeat;
 }
 
+main .asset-results-source {
+  grid-area: source;
+}
+
 main .asset-results-grid .asset-results-views, main .asset-results-grid .asset-results-dimensions, main .asset-results-grid .asset-results-tags {
   display: none;
 }
@@ -169,10 +173,6 @@ main .asset-results-masonry-item {
 main p.asset-results-caption {
   font-weight: bold;
   grid-area: caption;
-}
-
-main .asset-results-source {
-  grid-area: source;
 }
 
 main .asset-results-masonry-item p.asset-results-caption {

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -219,8 +219,8 @@ export default function decorate(block) {
         <a href="${detailURL}" data-assetid="${hit.assetID}">${picture.outerHTML}</a>
         <div class="asset-results-details source-${hit.sourceType}">
           <p class="asset-results-caption"><a href="${detailURL}" data-assetid="${hit.assetID}">${description}</a></p>
-          <!-- <p class="asset-results-source"><a href="${topurl.href}">${path}</a></p> -->
-          <!-- <p class="asset-results-views">${humanSize(hit.views)}</p> -->
+          <p class="asset-results-source"><a href="${topurl.href}">${path}</a></p>
+          <p class="asset-results-views">${humanSize(hit.views)}</p>
           <p class="asset-results-dimensions">${hit.height} x ${hit.width}</p>
           <p class="asset-results-tags"><span>${(hit.tags || []).join('</span> <span>')}</span></p>
         </div>

--- a/blocks/asset-results/asset-results.js
+++ b/blocks/asset-results/asset-results.js
@@ -218,11 +218,12 @@ export default function decorate(block) {
     };
     const modal = document.createElement('div');
     modal.classList.add('asset-results-oneup');
+
     modal.innerHTML = `<header>
       <div class="header block" data-block-name="header" data-block-status="loaded">
       <div class="header-brand">
-        <a href="http://localhost:3000/?q=assetID%3A12e16e067b6259f02449f35a35c5b2f7505550167&amp;index=assets"><img src="/styles/adobe.svg"></a>
-        Helix Assets
+        <a href="${window.location.origin}"><img src="${window.tenantLogo}"></a>
+        ${window.tenantTitle}
       </div>
       <div class="header-filename"></div>
       <div class="header-button">
@@ -298,6 +299,7 @@ export default function decorate(block) {
 
     const similarserviceurl = new URL('https://helix-pages.anywhere.run/helix-services/asset-ingestor@v1');
     similarserviceurl.searchParams.set('url', asset.image);
+    similarserviceurl.searchParams.set('tenant', window.tenant);
 
     try {
       const res = await fetch(similarserviceurl.href);
@@ -320,9 +322,13 @@ export default function decorate(block) {
   };
 
   const search = () => {
+    if (!window.algoliaApiKey) {
+      return;
+    }
+
     const myurl = new URL(window.location.href);
     const query = myurl.searchParams.get('q') || '';
-    const index = myurl.searchParams.get('index') || 'assets';
+    const index = myurl.searchParams.get('index') || `${window.tenant}_assets`;
 
     const terms = query.split(' ');
 
@@ -340,10 +346,10 @@ export default function decorate(block) {
       .join(' AND ');
     const words = terms.filter((term) => !term.match(':')).join(' ');
 
-    const url = new URL(`https://SWFXY1CU7X-dsn.algolia.net/1/indexes/${index}`);
+    const url = new URL(`https://${window.alogliaApplicationId}-dsn.algolia.net/1/indexes/${index}`);
     url.searchParams.set('query', words);
-    url.searchParams.set('x-algolia-api-key', 'bd35440a1d9feb709a052226f1aa70d8');
-    url.searchParams.set('x-algolia-application-id', 'SWFXY1CU7X');
+    url.searchParams.set('x-algolia-api-key', window.algoliaApiKey);
+    url.searchParams.set('x-algolia-application-id', window.alogliaApplicationId);
     // only one objectID per assetID
     // (search for "a person wearing sunglasses" for test)
     url.searchParams.set('distinct', !filters.match(/assetID:/));

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,7 +1,16 @@
 export default async function decorate(block) {
-  const selfURL = new URL(window.location.href);
-  selfURL.searchParams.set('index', selfURL.searchParams.get('index') === 'assets' ? 'assets-cai' : 'assets');
-  block.innerHTML = `<div class="header-brand"><a href="${selfURL.href}"><img src="/styles/adobe.svg"></a>Assets Across Adobe</div><div class="header-input"><span><input placeholder="Landscape Type to search..."></span></div><div class="header-button"></div>`;
+  // allow switching between tineye-based index and CAI index
+  // const u = new URL(window.location.href);
+  // u.searchParams.set('index', u.searchParams.get('index') === 'assets' ? 'assets-cai':'assets');
+
+  block.innerHTML = `<div class="header-brand">
+    <a href="${window.location.origin}"><img src="${window.tenantLogo}"></a>
+    ${window.tenantTitle}
+  </div>
+  <div class="header-input">
+    <span><input placeholder="Landscape Type to search..."></span>
+  </div>
+  <div class="header-button"></div>`;
 
   const textfield = block.querySelector('input');
 
@@ -35,7 +44,7 @@ export default async function decorate(block) {
     canvas.remove();
     const data = new URLSearchParams();
     data.set('upload', upload);
-    const res = await fetch('https://helix-pages.anywhere.run/helix-services/asset-ingestor@v1', {
+    const res = await fetch(`https://helix-pages.anywhere.run/helix-services/asset-ingestor@v1?index=${window.tenant}_assets`, {
       method: 'POST',
       headers: {
         'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
@@ -53,16 +62,20 @@ export default async function decorate(block) {
 
   // update the URL when the input changes
   textfield.addEventListener('input', () => {
+    if (!window.algoliaApiKey) {
+      return;
+    }
+
     const myurl = new URL(window.location.href);
     myurl.searchParams.set('q', textfield.value);
     window.changeURLState({ query: textfield.value }, myurl.href);
 
     const query = myurl.searchParams.get('q');
 
-    const url = new URL('https://SWFXY1CU7X-dsn.algolia.net/1/indexes/assets_query_suggestions');
+    const url = new URL(`https://${window.alogliaApplicationId}-dsn.algolia.net/1/indexes/${window.tenant}_assets_query_suggestions`);
     url.searchParams.set('query', query);
-    url.searchParams.set('x-algolia-api-key', 'bd35440a1d9feb709a052226f1aa70d8');
-    url.searchParams.set('x-algolia-application-id', 'SWFXY1CU7X');
+    url.searchParams.set('x-algolia-api-key', window.algoliaApiKey);
+    url.searchParams.set('x-algolia-application-id', window.alogliaApplicationId);
 
     fetch(url.href).then(async (res) => {
       const { hits } = await res.json();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -636,6 +636,76 @@ function buildFilterBlock(main) {
   wrapperdiv.prepend(buildBlock('filters', { elems: [filterdiv] }));
 }
 
+async function testAlgoliaConnection(tenant, apiKey) {
+  const url = new URL(`https://${window.alogliaApplicationId}-dsn.algolia.net/1/indexes/${tenant}_assets`);
+  url.searchParams.set('x-algolia-api-key', apiKey);
+  url.searchParams.set('x-algolia-application-id', window.alogliaApplicationId);
+  url.searchParams.set('query', '');
+  url.searchParams.set('hitsPerPage', 0);
+
+  const response = await fetch(url.href);
+  return response.status === 200;
+}
+
+async function login() {
+  window.alogliaApplicationId = 'SWFXY1CU7X';
+
+  // tenant
+
+  const domain = window.location.hostname;
+  const m = domain.match(/(.*)\.hlx\.media/);
+  if (m) {
+    // pilot customer domains
+    // eslint-disable-next-line prefer-destructuring
+    window.tenant = m[1];
+  } else {
+    // developer override
+    const tenant = new URL(window.location.href).searchParams.get('tenant');
+    if (tenant) {
+      window.tenant = tenant;
+    } else {
+      // fallback - original site
+      window.tenant = 'adobe';
+    }
+  }
+
+  window.tenantTitle = 'Assets across Adobe';
+  window.tenantLogo = '/styles/adobe.svg';
+
+  // api key (password)
+
+  if (window.tenant === 'adobe') {
+    window.algoliaApiKey = 'a3a03f2ea4a053b7ea033ab3abf96792';
+    return;
+  }
+
+  const savedKey = window.localStorage.getItem('algoliaApiKey');
+  if (savedKey) {
+    window.algoliaApiKey = savedKey;
+    return;
+  }
+
+  let msg = 'Welcome!';
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // eslint-disable-next-line no-alert
+    const apiKey = prompt(`${msg}\n\nPassword for ${window.tenant}:`);
+    if (apiKey) {
+      // eslint-disable-next-line no-await-in-loop
+      if (await testAlgoliaConnection(window.tenant, apiKey)) {
+        window.algoliaApiKey = apiKey;
+        window.localStorage.setItem('algoliaApiKey', apiKey);
+        return;
+      }
+      msg = 'Sorry, the password is incorrect, please try again.';
+    } else {
+      document.body.innerHTML = '<div class="logout">You are not logged in. Please refresh page to login again.</div>';
+      return;
+    }
+  }
+}
+
 function loadHeader(header) {
   const headerBlock = buildBlock('header', '');
   header.append(headerBlock);
@@ -698,6 +768,8 @@ async function loadEager(doc) {
  * loads everything that doesn't need to be delayed.
  */
 async function loadLazy(doc) {
+  await login();
+
   const main = doc.querySelector('main');
   await loadBlocks(main);
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -238,3 +238,10 @@ main .section[data-section-status='initialized'] {
 main .section.highlight {
   background-color: var(--highlight-background-color);
 }
+
+div.logout {
+  right: 50%;
+  bottom: 50%;
+  transform: translate(50%,50%);
+  position: absolute;
+}


### PR DESCRIPTION
Will pick the tenant based on
* domain being `<tenant>.hlx.media` => ask user for password (algolia api key for that tenant)
* domain being `adobe.hlx.media` => no password needed (existing public site)

Password/api key is stored in localStorage so it's persistent per domain.

To test it, simulate a tenant using the `?tenant=testcustomer` query paramater. Requires aloglia api readonly key for the `testcustomer_assets` index to enter as password.
* https://login2--helix-assets-ui--adobe.hlx3.page/?tenant=testcustomer

Furthermore we can set some tenant branding (in `scripts.js`), which can be different in the branches:
* `window.tenantTitle` for the title - default "Assets Across Adobe"
* `window.tenantLogo` for the icon - defaults to "/styles/adobe.svg"

Maybe that needs to be pulled in from a separate config.js script or so to avoid merge conflicts.

Test URLs:

* https://login2--helix-assets-ui--adobe.hlx3.page
* https://login2--helix-assets-ui--adobe.hlx3.page/?q=#sidebar
* https://login2--helix-assets-ui--adobe.hlx3.page/?assetId=1e4df33b1cb33045d3ebb32c7d848e037c055f6f6